### PR TITLE
make profileExtender public

### DIFF
--- a/mPowerSDK/Startup/APHAppDelegate.h
+++ b/mPowerSDK/Startup/APHAppDelegate.h
@@ -32,6 +32,7 @@
 // 
  
 #import <UIKit/UIKit.h>
+#import "APHProfileExtender.h"
 @import APCAppCore;
 
 @class APHProfileExtender;
@@ -45,6 +46,7 @@
 @property  (nonatomic, readonly) NSInteger environment;
 @property  (nonatomic, readonly) NSArray <APCTaskReminder *> * _Nonnull allTaskReminders;
 @property  (nonatomic, readonly) NSDictionary * _Nonnull appearanceInfo;
+@property  (nonatomic, strong)  APHProfileExtender * _Nullable profileExtender;
 
 @end
 

--- a/mPowerSDK/Startup/APHAppDelegate.m
+++ b/mPowerSDK/Startup/APHAppDelegate.m
@@ -33,7 +33,6 @@
 
 @import APCAppCore;
 #import "APHAppDelegate.h"
-#import "APHProfileExtender.h"
 #import "APHDataKeys.h"
 #import "APHLocalization.h"
 
@@ -56,7 +55,6 @@ static NSString *const kJsonSchedulesKey                = @"schedules";
 static NSString *const kAppStoreLink                    = @"https://appsto.re/us/GxN85.i";
 
 @interface APHAppDelegate ()
-@property  (nonatomic, strong)  APHProfileExtender* profileExtender;
 @end
 
 @implementation APHAppDelegate


### PR DESCRIPTION
so APHFinalAppDelegate can access it (so there can be a strong reference to the profile extender so it doesn't go away as soon as the caller returns)
