### PR TITLE
Tremor assessment

### DIFF
--- a/mPowerSDK.xcodeproj/project.pbxproj
+++ b/mPowerSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B41081B1C73E2BF00A2FB7B /* APHTremorTaskViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B4108191C73E2BF00A2FB7B /* APHTremorTaskViewController.h */; };
+		6B41081C1C73E2BF00A2FB7B /* APHTremorTaskViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B41081A1C73E2BF00A2FB7B /* APHTremorTaskViewController.m */; };
 		FF0B4AC01C29FCB800224EF7 /* APHParkinsonActivityViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = FF0B4AAE1C29FCB800224EF7 /* APHParkinsonActivityViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF0B4AC11C29FCB800224EF7 /* APHParkinsonActivityViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0B4AAF1C29FCB800224EF7 /* APHParkinsonActivityViewController.m */; };
 		FF0B4AC21C29FCB800224EF7 /* APHScoreCalculator.h in Headers */ = {isa = PBXBuildFile; fileRef = FF0B4AB01C29FCB800224EF7 /* APHScoreCalculator.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -101,6 +103,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6B4108191C73E2BF00A2FB7B /* APHTremorTaskViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APHTremorTaskViewController.h; sourceTree = "<group>"; };
+		6B41081A1C73E2BF00A2FB7B /* APHTremorTaskViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APHTremorTaskViewController.m; sourceTree = "<group>"; };
 		FF0B4AAE1C29FCB800224EF7 /* APHParkinsonActivityViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APHParkinsonActivityViewController.h; sourceTree = "<group>"; };
 		FF0B4AAF1C29FCB800224EF7 /* APHParkinsonActivityViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = APHParkinsonActivityViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FF0B4AB01C29FCB800224EF7 /* APHScoreCalculator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APHScoreCalculator.h; sourceTree = "<group>"; };
@@ -224,6 +228,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6B4108181C73E21D00A2FB7B /* TremorControllers */ = {
+			isa = PBXGroup;
+			children = (
+				6B4108191C73E2BF00A2FB7B /* APHTremorTaskViewController.h */,
+				6B41081A1C73E2BF00A2FB7B /* APHTremorTaskViewController.m */,
+			);
+			path = TremorControllers;
+			sourceTree = "<group>";
+		};
 		FF0B4AAD1C29FCB800224EF7 /* TasksAndSteps */ = {
 			isa = PBXGroup;
 			children = (
@@ -237,6 +250,7 @@
 				FF0B4AB31C29FCB800224EF7 /* IntervalTappingControllers */,
 				FF0B4AB71C29FCB800224EF7 /* PhonationControllers */,
 				FF0B4ABA1C29FCB800224EF7 /* SpatialSpanMemoryControllers */,
+				6B4108181C73E21D00A2FB7B /* TremorControllers */,
 				FF0B4ABD1C29FCB800224EF7 /* WalkingControllers */,
 			);
 			path = TasksAndSteps;
@@ -502,6 +516,7 @@
 				FFFA24911C236E9A00727DA8 /* APHProfileExtender.h in Headers */,
 				FF2D344E1C3207060033838A /* APHActivityManager.h in Headers */,
 				FFFA24C71C237E1500727DA8 /* APHDashboardViewController.h in Headers */,
+				6B41081B1C73E2BF00A2FB7B /* APHTremorTaskViewController.h in Headers */,
 				FF2D34421C31B7DC0033838A /* APHLocalization.h in Headers */,
 				FFFA24C51C237E1500727DA8 /* APHDashboardEditViewController.h in Headers */,
 				FF2D8BD81C497D28004EC642 /* APHMedicationTrackerTask.h in Headers */,
@@ -636,6 +651,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B41081C1C73E2BF00A2FB7B /* APHTremorTaskViewController.m in Sources */,
 				FF0B4ACC1C29FCB800224EF7 /* APHWalkingTaskViewController.m in Sources */,
 				FFFA24C61C237E1500727DA8 /* APHDashboardEditViewController.m in Sources */,
 				FF95C0441C4EB4A90081672E /* APHMedication.m in Sources */,

--- a/mPowerSDK/APHDataKeys.h
+++ b/mPowerSDK/APHDataKeys.h
@@ -36,6 +36,7 @@ extern NSString *const APHWalkingActivitySurveyIdentifier;
 extern NSString *const APHVoiceActivitySurveyIdentifier;
 extern NSString *const APHTappingActivitySurveyIdentifier;
 extern NSString *const APHMemoryActivitySurveyIdentifier;
+extern NSString *const APHTremorActivitySurveyIdentifier;
 extern NSString *const APHEnrollmentSurveyIdentifier;
 extern NSString *const APHMyThoughtsSurveyIdentifier;
 extern NSString *const APHFeedbackSurveyIdentifier;

--- a/mPowerSDK/APHDataKeys.m
+++ b/mPowerSDK/APHDataKeys.m
@@ -36,11 +36,11 @@ NSString *const APHWalkingActivitySurveyIdentifier              = @"4-APHTimedWa
 NSString *const APHVoiceActivitySurveyIdentifier                = @"3-APHPhonation-C614A231-A7B7-4173-BDC8-098309354292";
 NSString *const APHTappingActivitySurveyIdentifier              = @"2-APHIntervalTapping-7259AC18-D711-47A6-ADBD-6CFCECDED1DF";
 NSString *const APHMemoryActivitySurveyIdentifier               = @"7-APHSpatialSpanMemory-4A04F3D0-AC05-11E4-AB27-0800200C9A66";
-NSString *const APHTremorActivitySurveyIdentifier               = @"0-APHTremorAssessment-00000000-0000-0000-0000-000000000000"; // TODO: update identifier
 NSString *const APHEnrollmentSurveyIdentifier                   = @"1-EnrollmentSurvey-20EF83D2-E461-4C20-9024-F43FCAAAF4C3";
 NSString *const APHMyThoughtsSurveyIdentifier                   = @"8-MyThoughts-12ffde40-1551-4b48-aae2-8fef38d61b61";
 NSString *const APHFeedbackSurveyIdentifier                     = @"9-Feedback-394348ce-ca4f-4abe-b97e-fedbfd7ffb8e";
 NSString *const APHMedicationTrackerSurveyIdentifier            = @"1-APHMedicationTracker-20EF8ED2-E461-4C20-9024-F43FCAAAF4C3";
+NSString *const APHTremorActivitySurveyIdentifier               = @"1-APHTremor-108E189F-4B5B-48DC-BFD7-FA6796EEf439";
 
 NSString *const APHPhonationScoreSummaryOfRecordsKey            = @"ScoreSummaryOfRecords";
 NSString *const APHRightSummaryNumberOfRecordsKey               = @"SummaryNumberOfRecords";

--- a/mPowerSDK/APHDataKeys.m
+++ b/mPowerSDK/APHDataKeys.m
@@ -36,6 +36,7 @@ NSString *const APHWalkingActivitySurveyIdentifier              = @"4-APHTimedWa
 NSString *const APHVoiceActivitySurveyIdentifier                = @"3-APHPhonation-C614A231-A7B7-4173-BDC8-098309354292";
 NSString *const APHTappingActivitySurveyIdentifier              = @"2-APHIntervalTapping-7259AC18-D711-47A6-ADBD-6CFCECDED1DF";
 NSString *const APHMemoryActivitySurveyIdentifier               = @"7-APHSpatialSpanMemory-4A04F3D0-AC05-11E4-AB27-0800200C9A66";
+NSString *const APHTremorActivitySurveyIdentifier               = @"0-APHTremorAssessment-00000000-0000-0000-0000-000000000000"; // TODO: update identifier
 NSString *const APHEnrollmentSurveyIdentifier                   = @"1-EnrollmentSurvey-20EF83D2-E461-4C20-9024-F43FCAAAF4C3";
 NSString *const APHMyThoughtsSurveyIdentifier                   = @"8-MyThoughts-12ffde40-1551-4b48-aae2-8fef38d61b61";
 NSString *const APHFeedbackSurveyIdentifier                     = @"9-Feedback-394348ce-ca4f-4abe-b97e-fedbfd7ffb8e";

--- a/mPowerSDK/Dashboard/APHDashboardEditViewController.h
+++ b/mPowerSDK/Dashboard/APHDashboardEditViewController.h
@@ -42,7 +42,8 @@ typedef NS_ENUM(APCTableViewItemType, APHDashboardItemType) {
     kAPHDashboardItemTypeSteps,
     kAPHDashboardItemTypeAlerts,
     kAPHDashboardItemTypeInsights,
-    kAPHDashboardItemTypeCorrelation
+    kAPHDashboardItemTypeCorrelation,
+    kAPHDashboardItemTypeTremor
 };
 
 @interface APHDashboardEditViewController : APCDashboardEditViewController

--- a/mPowerSDK/Dashboard/APHDashboardEditViewController.m
+++ b/mPowerSDK/Dashboard/APHDashboardEditViewController.m
@@ -122,6 +122,17 @@
                 }
                     break;
                     
+                case kAPHDashboardItemTypeTremor:
+                {
+                    APCTableViewDashboardItem *item = [APCTableViewDashboardItem new];
+                    item.caption = NSLocalizedStringWithDefaultValue(@"APH_TREMOR_CAPTION", nil, APHLocaleBundle(), @"Tremor", @"Dashboard caption for results of tremor activity.");
+                    item.taskId = APHTremorActivitySurveyIdentifier;
+                    item.tintColor = [UIColor colorForTaskId:item.taskId];
+                    
+                    [self.items addObject:item];
+                }
+                    break;
+                    
                 default:
                     break;
             }

--- a/mPowerSDK/Dashboard/APHDashboardViewController.m
+++ b/mPowerSDK/Dashboard/APHDashboardViewController.m
@@ -142,6 +142,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
       @(kAPHDashboardItemTypeSpatialMemory),
       @(kAPHDashboardItemTypePhonation),
       @(kAPHDashboardItemTypeGait),
+      @(kAPHDashboardItemTypeTremor),
       @(kAPHDashboardItemTypeDailyMood),
       @(kAPHDashboardItemTypeDailyEnergy),
       @(kAPHDashboardItemTypeDailyExercise),

--- a/mPowerSDK/Dashboard/APHDashboardViewController.m
+++ b/mPowerSDK/Dashboard/APHDashboardViewController.m
@@ -142,7 +142,6 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
       @(kAPHDashboardItemTypeSpatialMemory),
       @(kAPHDashboardItemTypePhonation),
       @(kAPHDashboardItemTypeGait),
-      @(kAPHDashboardItemTypeTremor),
       @(kAPHDashboardItemTypeDailyMood),
       @(kAPHDashboardItemTypeDailyEnergy),
       @(kAPHDashboardItemTypeDailyExercise),

--- a/mPowerSDK/Dashboard/APHDashboardViewController.m
+++ b/mPowerSDK/Dashboard/APHDashboardViewController.m
@@ -37,6 +37,7 @@
 #import "APHDataKeys.h"
 #import "APHLocalization.h"
 #import "APHSpatialSpanMemoryGameViewController.h"
+#import "APHTremorTaskViewController.h"
 #import "APHWalkingTaskViewController.h"
 
 
@@ -53,6 +54,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 @property (nonatomic, strong) APCScoring *stepScoring;
 @property (nonatomic, strong) APCScoring *memoryScoring;
 @property (nonatomic, strong) APCScoring *phonationScoring;
+@property (nonatomic, strong) APCScoring *tremorScoring;
 
 @end
 
@@ -77,6 +79,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                               
             if ([APCDeviceHardware isiPhone5SOrNewer]) {
                 [_rowItemsOrder addObject:@(kAPHDashboardItemTypeGait)];
+                [_rowItemsOrder addObject:@(kAPHDashboardItemTypeTremor)];
             }
             [defaults setObject:[NSArray arrayWithArray:_rowItemsOrder] forKey:kAPCDashboardRowItemsOrder];
             [defaults synchronize];
@@ -164,6 +167,11 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                                                                     unit:[HKUnit countUnit]
                                                             numberOfDays:-kNumberOfDaysToDisplay];
     self.stepScoring.caption = NSLocalizedStringWithDefaultValue(@"APH_STEPS_CAPTION", nil, APHLocaleBundle(), @"Steps", @"Dashboard caption for results of steps score.");
+    
+    self.tremorScoring = [[APCScoring alloc] initWithTask:APHTremorActivitySurveyIdentifier
+                                             numberOfDays:-kNumberOfDaysToDisplay
+                                                 valueKey:kTremorScoreKey];
+    self.tremorScoring.caption = NSLocalizedStringWithDefaultValue(@"APH_TREMOR_CAPTION", nil, APHLocaleBundle(), @"Tremor", @"Dashboard caption for results of tremor score.");
     
     if (!self.correlatedScoring) {
         [self prepareCorrelatedScoring];
@@ -320,7 +328,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     item.editable = YES;
                     item.tintColor = [UIColor colorForTaskId:item.taskId];
                     
-                    item.info = NSLocalizedStringWithDefaultValue(@"APH_DASHBOARD_MEMORY_INFO", nil, APHLocaleBundle(), @"This plot shows the score you received each day for the Memory Game. The length and position of each vertical bar represents the range of scores for a given day. Any differences in length or position over time reflect variations and trends in your score, which may reflect variations and trends in your symptoms.", @"Dashboard tooltip item info text for Memory in Parkinson");
+                    item.info = NSLocalizedStringWithDefaultValue(@"APH_DASHBOARD_MEMORY_INFO", nil, APHLocaleBundle(), @"== The length and position of each vertical bar represents the range of scores for a given day. Any differences in length or position over time reflect variations and trends in your score, which may reflect variations and trends in your symptoms.", @"Dashboard tooltip item info text for Memory in Parkinson");
                     
                     APCTableViewRow *row = [APCTableViewRow new];
                     row.item = item;
@@ -381,6 +389,33 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     [rowItems addObject:row];
                 }
                     break;
+                    
+                case kAPHDashboardItemTypeTremor:
+                {
+                    APCTableViewDashboardGraphItem  *item = [APCTableViewDashboardGraphItem new];
+                    item.caption = self.tremorScoring.caption;
+                    item.graphData = self.tremorScoring;
+                    
+                    double avgValue = [[self.tremorScoring averageDataPoint] doubleValue];
+                    
+                    if (avgValue > 0) {
+                        item.detailText = [NSString stringWithFormat:detailAvgFormat,
+                                           APHLocalizedStringFromNumber([self.tremorScoring averageDataPoint])];
+                    }
+                    
+                    item.reuseIdentifier = kAPCDashboardGraphTableViewCellIdentifier;
+                    item.editable = YES;
+                    item.tintColor = [UIColor colorForTaskId:APHTremorActivitySurveyIdentifier];
+                    
+                    item.info = NSLocalizedStringWithDefaultValue(@"APH_DASHBOARD_TREMOR_INFO", nil, APHLocaleBundle(), @"This plot shows the score you received each day for the Tremor Test.", @"Dashboard tooltip item info text for Tremor Test in Parkinson");
+                    
+                    APCTableViewRow *row = [APCTableViewRow new];
+                    row.item = item;
+                    row.itemType = rowType;
+                    [rowItems addObject:row];
+                }
+                    break;
+                    
                 default:
                     break;
             }

--- a/mPowerSDK/Resources/JSONs/APHTaskIdToViewControllerMapping.json
+++ b/mPowerSDK/Resources/JSONs/APHTaskIdToViewControllerMapping.json
@@ -3,5 +3,6 @@
     "3-APHPhonation-C614A231-A7B7-4173-BDC8-098309354292"           : "APHPhonationTaskViewController",
     "2-APHIntervalTapping-7259AC18-D711-47A6-ADBD-6CFCECDED1DF"     : "APHIntervalTappingTaskViewController",
     "7-APHSpatialSpanMemory-4A04F3D0-AC05-11E4-AB27-0800200C9A66"   : "APHSpatialSpanMemoryGameViewController",
-    "1-APHMedicationTracker-20EF8ED2-E461-4C20-9024-F43FCAAAF4C3"   : "APHMedicationTrackerViewController"
+    "1-APHMedicationTracker-20EF8ED2-E461-4C20-9024-F43FCAAAF4C3"   : "APHMedicationTrackerViewController",
+    "1-APHTremor-108E189F-4B5B-48DC-BFD7-FA6796EEf439"              : "APHTremorTaskViewController"
 }

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -136,8 +136,15 @@ static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
     }
     
     // Replace the language in the last step
-    [task.steps.lastObject setTitle:NSLocalizedStringWithDefaultValue(@"APH_ACTIVITY_CONCLUSION_TEXT", nil, APHLocaleBundle(), @"Thank You!", @"Main text shown to participant upon completion of an activity.")];
-    [task.steps.lastObject setText:NSLocalizedStringWithDefaultValue(@"APH_ACTIVITY_CONCLUSION_DETAIL", nil, APHLocaleBundle(), @"The results of this activity can be viewed on the dashboard", @"Detail text shown to participant upon completion of an activity.")];
+    ORKStep *lastStep = task.steps.lastObject;
+    [lastStep setTitle:NSLocalizedStringWithDefaultValue(@"APH_ACTIVITY_CONCLUSION_TEXT", nil, APHLocaleBundle(), @"Thank You!", @"Main text shown to participant upon completion of an activity.")];
+    
+    // Tremor scores for display in dashboard are not yet available
+    if ([surveyId isEqualToString:APHTremorActivitySurveyIdentifier]) {
+        [lastStep setText:NSLocalizedStringWithDefaultValue(@"APH_ACTIVITY_CONCLUSION_DETAIL_NODASH", nil, APHLocaleBundle(), @"You have completed this activity", @"Detail text shown to participant upon completion of an activity (without mention of the dashboard).")];
+    } else {
+        [lastStep setText:NSLocalizedStringWithDefaultValue(@"APH_ACTIVITY_CONCLUSION_DETAIL", nil, APHLocaleBundle(), @"The results of this activity can be viewed on the dashboard", @"Detail text shown to participant upon completion of an activity.")];
+    }
     
     // Create a medication tracker task with this as a subtask
     return [[APHMedicationTrackerTask alloc] initWithDictionaryRepresentation:nil subTask:task];

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -88,6 +88,12 @@ static  NSString       *kWalkingActivityTitle                 = @"Walking Activi
 static  NSUInteger      kNumberOfStepsPerLeg                  = 20;
 static  NSTimeInterval  kStandStillDuration                   = 30.0;
 
+//
+// constants for setting up the tremor activity
+//
+static NSString *const kTremorAssessmentTitleIdentifier     = @"Tremor Activity";
+static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
+
 
 @interface APHActivityManager ()
 
@@ -122,6 +128,9 @@ static  NSTimeInterval  kStandStillDuration                   = 30.0;
     }
     else if ([surveyId isEqualToString:APHWalkingActivitySurveyIdentifier]) {
         task = [self createCustomWalkingTask];
+    }
+    else if ([surveyId isEqualToString:APHTremorActivitySurveyIdentifier]) {
+        task = [self createCustomTremorTask];
     }
     
     // Replace the language in the last step
@@ -248,6 +257,14 @@ static  NSTimeInterval  kStandStillDuration                   = 30.0;
     orkTask = [[ORKOrderedTask alloc] initWithIdentifier:kWalkingActivityTitle steps:copyOfTaskSteps];
     
     return  orkTask;
+}
+
+- (ORKOrderedTask *)createCustomTremorTask
+{
+    return [ORKOrderedTask tremorTestTaskWithIdentifier:kTremorAssessmentTitleIdentifier
+                                 intendedUseDescription:nil
+                                     activeStepDuration:kTremorAssessmentStepDuration
+                                                options:ORKPredefinedTaskOptionNone];
 }
 
 @end

--- a/mPowerSDK/TasksAndSteps/APHScoreCalculator.h
+++ b/mPowerSDK/TasksAndSteps/APHScoreCalculator.h
@@ -49,4 +49,7 @@
 - (double)scoreFromPostureURL:(NSURL *)url;
 - (double)scoreFromPostureTest:(NSArray *)postureData;
 
+- (double)scoreFromTremorAccelerometerURL:(NSURL *)accelerometerURL motionURL:(NSURL *)motionURL;
+- (double)scoreFromTremorTestAccelerometerData:(NSArray *)tremorAccelerometerData motionData:(NSArray *)motionData;
+
 @end

--- a/mPowerSDK/TasksAndSteps/APHScoreCalculator.m
+++ b/mPowerSDK/TasksAndSteps/APHScoreCalculator.m
@@ -153,6 +153,17 @@ static  NSString  *kTappingSamplesKey = @"TappingSamples";
     }
 }
 
+- (double)scoreFromTremorAccelerometerURL:(NSURL *)accelerometerURL motionURL:(NSURL *)motionURL
+{
+    NSArray *accelerometerData = [self convertPostureOrGain:accelerometerURL];
+    NSArray *motionData = [self convertPostureOrGain:motionURL];
+    if (accelerometerData.count == 0 || motionData.count == 0) {
+        return 0.0;
+    } else {
+        return [self scoreFromTremorTestAccelerometerData:accelerometerData motionData:motionData];
+    }
+}
+
 - (double)scoreFromTappingTest:(NSArray *)tappingData
 {
     return [PDScores scoreFromTappingTest:tappingData];
@@ -171,6 +182,14 @@ static  NSString  *kTappingSamplesKey = @"TappingSamples";
 - (double)scoreFromPostureTest:(NSArray *)postureData
 {
     return [PDScores scoreFromPostureTest:postureData];
+}
+
+- (double)scoreFromTremorTestAccelerometerData:(NSArray *)tremorAccelerometerData motionData:(NSArray *)tremorMotionData
+{
+    // TODO: implement tremor calculation support in PDScores (Jake Krog - 2/29/2016)
+    // return [PDScores scoreFromTremorTestAccelerometerData:tremorAccelerometerData motionData:tremorMotionData];
+    
+    return 0.0;
 }
 
 @end

--- a/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.h
+++ b/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.h
@@ -8,6 +8,8 @@
 
 #import <mPowerSDK/mPowerSDK.h>
 
+extern NSString * const kTremorScoreKey;
+
 @interface APHTremorTaskViewController : APHParkinsonActivityViewController
 
 @end

--- a/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.h
+++ b/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.h
@@ -1,0 +1,13 @@
+//
+//  APHTremorTaskViewController.h
+//  mPowerSDK
+//
+//  Created by Jake Krog on 2016-02-16.
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+
+#import <mPowerSDK/mPowerSDK.h>
+
+@interface APHTremorTaskViewController : APHParkinsonActivityViewController
+
+@end

--- a/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.m
+++ b/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.m
@@ -1,0 +1,51 @@
+//
+//  APHTremorTaskViewController.m
+//  mPowerSDK
+//
+//  Created by Jake Krog on 2016-02-16.
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+
+#import "APHTremorTaskViewController.h"
+
+@interface APHTremorTaskViewController ()
+
+@end
+
+@implementation APHTremorTaskViewController
+
+#pragma  mark  -  Task Creation Methods
+
++ (id<ORKTask>)createOrkTask:(APCTask *) __unused scheduledTask
+{
+    return  [[APHActivityManager defaultManager] createTaskForSurveyId:APHTremorActivitySurveyIdentifier];
+}
+
+
+#pragma  mark  -  Results For Dashboard
+
+- (NSString *)createResultSummary
+{
+    // TODO: implement this
+    return nil;
+}
+
+
+/*
+- (BOOL)preferStatusBarShouldBeHiddenForStep:(ORKStep*)step {
+    return [step.identifier hasPrefix:APCTapTappingStepIdentifier];
+}
+ */
+
+
+#pragma  mark  -  View Controller Methods
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    [[UIView appearance] setTintColor:[UIColor appPrimaryColor]];
+    self.preferStatusBarShouldBeHidden = NO;
+}
+
+@end

--- a/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.m
+++ b/mPowerSDK/TasksAndSteps/TremorControllers/APHTremorTaskViewController.m
@@ -8,6 +8,8 @@
 
 #import "APHTremorTaskViewController.h"
 
+NSString * const kTremorScoreKey = @"TremorScoreKey";
+
 @interface APHTremorTaskViewController ()
 
 @end
@@ -26,16 +28,26 @@
 
 - (NSString *)createResultSummary
 {
-    // TODO: implement this
+    ORKTaskResult *taskResult = self.result;
+    self.createResultSummaryBlock = ^(NSManagedObjectContext *context) {
+        
+        // TODO: calculate tremor score from results (Jake Krog - 2/23/2016)
+        NSDictionary *summary = @{ kTremorScoreKey: @0 };
+        
+        NSError  *error = nil;
+        NSData  *data = [NSJSONSerialization dataWithJSONObject:summary options:0 error:&error];
+        NSString *contentString = nil;
+        if (data == nil) {
+            APCLogError2 (error);
+        } else {
+            contentString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        }
+        if (contentString.length > 0) {
+            [APCResult updateResultSummary:contentString forTaskResult:taskResult inContext:context];
+        }
+    };
     return nil;
 }
-
-
-/*
-- (BOOL)preferStatusBarShouldBeHiddenForStep:(ORKStep*)step {
-    return [step.identifier hasPrefix:APCTapTappingStepIdentifier];
-}
- */
 
 
 #pragma  mark  -  View Controller Methods

--- a/mPowerSDKTests/APHActivityManagerTests.m
+++ b/mPowerSDKTests/APHActivityManagerTests.m
@@ -129,11 +129,11 @@
     APHMedicationTrackerTask *medTask = (APHMedicationTrackerTask *)[manager createTaskForSurveyId:APHTremorActivitySurveyIdentifier];
     ORKOrderedTask *task  = (ORKOrderedTask *)medTask.subTask;
     XCTAssertNotNil(task);
-    XCTAssertNotNil([task stepWithIdentifier:@"handInLap.withWristSensorAndPhone"]);
-    XCTAssertNotNil([task stepWithIdentifier:@"handAtShoulderLength.withWristSensorAndPhone"]);
-    XCTAssertNotNil([task stepWithIdentifier:@"handAtShoulderLengthWithElbowBent.withWristSensorAndPhone"]);
-    XCTAssertNotNil([task stepWithIdentifier:@"handToNose.withWristSensorAndPhone"]);
-    XCTAssertNotNil([task stepWithIdentifier:@"handQueenWave.withWristSensorAndPhone"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"tremor.handInLap"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"tremor.handAtShoulderLength"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"tremor.handAtShoulderLengthWithElbowBent"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"tremor.handToNose"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"tremor.handQueenWave"]);
     
     // Check that the final step uses the expected language
     ORKStep *finalStep = task.steps.lastObject;

--- a/mPowerSDKTests/APHActivityManagerTests.m
+++ b/mPowerSDKTests/APHActivityManagerTests.m
@@ -121,6 +121,26 @@
     XCTAssertEqualObjects(finalStep.text, @"The results of this activity can be viewed on the dashboard");
 }
 
+- (void)testCreateOrderedTask_Tremor_English
+{
+    [APHLocalization setLocalization:@"en"];
+    
+    APHActivityManager *manager = [[APHActivityManager alloc] init];
+    APHMedicationTrackerTask *medTask = (APHMedicationTrackerTask *)[manager createTaskForSurveyId:APHTremorActivitySurveyIdentifier];
+    ORKOrderedTask *task  = (ORKOrderedTask *)medTask.subTask;
+    XCTAssertNotNil(task);
+    XCTAssertNotNil([task stepWithIdentifier:@"handInLap.withWristSensorAndPhone"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"handAtShoulderLength.withWristSensorAndPhone"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"handAtShoulderLengthWithElbowBent.withWristSensorAndPhone"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"handToNose.withWristSensorAndPhone"]);
+    XCTAssertNotNil([task stepWithIdentifier:@"handQueenWave.withWristSensorAndPhone"]);
+    
+    // Check that the final step uses the expected language
+    ORKStep *finalStep = task.steps.lastObject;
+    XCTAssertEqualObjects(finalStep.title, @"Thank You!");
+    XCTAssertEqualObjects(finalStep.text, @"The results of this activity can be viewed on the dashboard");
+}
+
 @end
 
 

--- a/mPowerSDKTests/APHActivityManagerTests.m
+++ b/mPowerSDKTests/APHActivityManagerTests.m
@@ -138,7 +138,7 @@
     // Check that the final step uses the expected language
     ORKStep *finalStep = task.steps.lastObject;
     XCTAssertEqualObjects(finalStep.title, @"Thank You!");
-    XCTAssertEqualObjects(finalStep.text, @"The results of this activity can be viewed on the dashboard");
+    XCTAssertEqualObjects(finalStep.text, @"You have completed this activity");
 }
 
 @end


### PR DESCRIPTION
This PR adds support for the tremor assessment module in ResearchKit.

@Erin-Mounts:
Regarding the issue with result calculation you raised in the other PR, I have to admit I'm a bit out of my depth; I looked into the existing score calculation code over the weekend, but I don't know if any of the existing code for processing accelerometer / motion data is applicable here.

I added more logic to the tremor view controller to help with creating the result summary, but PDScores needs to be updated to support tremor assessment data. If you have any suggestions, please let me know - I'm happy to help in any way that I can.
