### PR TITLE
Remove red "Too Loud" indicators for voice active task

### DIFF
--- a/mPowerSDK/TasksAndSteps/PhonationControllers/APHPhonationTaskViewController.m
+++ b/mPowerSDK/TasksAndSteps/PhonationControllers/APHPhonationTaskViewController.m
@@ -34,6 +34,8 @@
 #import "APHPhonationTaskViewController.h"
 #import <AVFoundation/AVFoundation.h>
 #import <APCAppCore/APCAppCore.h>
+#import <ResearchKit/ORKAudioStep.h>
+#import <ResearchKit/ORKAudioStepViewController.h>
 #import "APHAppDelegate.h"
 #import "APHDataKeys.h"
 #import "APHScoreCalculator.h"
@@ -104,6 +106,18 @@ static const NSInteger kPhonationActivitySchemaRevision       = 3;
         return NO;
     }
     return YES;
+}
+
+- (ORKStepViewController *)taskViewController:(ORKTaskViewController *)taskViewController
+						viewControllerForStep:(ORKStep *)step {
+	if ([step isKindOfClass:[ORKAudioStep class]]) {
+		ORKAudioStepViewController *stepViewController = [[ORKAudioStepViewController alloc] initWithStep:step];
+		//remove "too loud" red indicator; requires ResearchKit commit 42aa4408dc04b6f856cccf33fc3fb4484ac728c4
+		stepViewController.alertThreshold = 1.f;
+		return stepViewController;
+	}
+
+	return nil;
 }
 
 - (void)taskViewController:(ORKTaskViewController *) __unused taskViewController didChangeResult:(ORKTaskResult *)result


### PR DESCRIPTION
Requires commit 42aa4408dc04b6f856cccf33fc3fb4484ac728c4 from ResearchKit
