### PR TITLE
Remove unwanted steps from Tremor activity

### DIFF
--- a/mPowerSDK/Dashboard/APHDashboardViewController.m
+++ b/mPowerSDK/Dashboard/APHDashboardViewController.m
@@ -158,7 +158,8 @@ static NSString * const kAPHMonthlyReportHTMLStepIdentifier    = @"report";
       @(kAPHDashboardItemTypeSpatialMemory),
       @(kAPHDashboardItemTypePhonation),
       @(kAPHDashboardItemTypeGait),
-      @(kAPHDashboardItemTypeTremor),
+      // TODO: Add this item when we implement scoring for Tremor activity -emm 2016-03-03
+//      @(kAPHDashboardItemTypeTremor),
       @(kAPHDashboardItemTypeDailyMood),
       @(kAPHDashboardItemTypeDailyEnergy),
       @(kAPHDashboardItemTypeDailyExercise),

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -93,14 +93,8 @@ static  NSTimeInterval  kWalkDuration                         = 30.0; // we'll s
 //
 // constants for setting up the tremor activity
 //
-static NSString *const kTremorElbowBentInstructionStepIdentifier    = @"instruction5";
-static NSString *const kTremorElbowBentCountdownStepIdentifier      = @"countdown3";
-static NSString *const kTremorElbowBentStepIdentifier               = @"tremor.handAtShoulderLengthWithElbowBent";
-static NSString *const kTremorQueenWaveInstructionStepIdentifier    = @"instruction7";
-static NSString *const kTremorQueenWaveCountdownStepIdentifier      = @"countdown5";
-static NSString *const kTremorQueenWaveStepIdentifier               = @"tremor.handQueenWave";
-static NSString *const kTremorAssessmentTitleIdentifier             = @"Tremor Activity";
-static NSTimeInterval kTremorAssessmentStepDuration                 = 10.0;
+static NSString *const kTremorAssessmentTitleIdentifier     = @"Tremor Activity";
+static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
 
 
 @interface APHActivityManager ()

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -287,7 +287,7 @@ static NSTimeInterval kTremorAssessmentStepDuration                 = 10.0;
 - (ORKOrderedTask *)createCustomTremorTask
 {
     ORKTremorActiveTaskOption excludeTasks =
-        ORKTremorActiveTaskOptionExcludeHandAtShoulderHeightElbowBent |ORKTremorActiveTaskOptionExcludeQueenWave;
+        ORKTremorActiveTaskOptionExcludeHandAtShoulderHeightElbowBent | ORKTremorActiveTaskOptionExcludeQueenWave;
     
     return [ORKOrderedTask tremorTestTaskWithIdentifier:kTremorAssessmentTitleIdentifier
                                  intendedUseDescription:nil

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -304,6 +304,18 @@ static NSTimeInterval kTremorAssessmentStepDuration                 = 10.0;
         }
     }
     
+    // move the "you're done" spoken instruction to the new last step
+    NSInteger oldFinalIndex = orkTask.steps.count - 2;
+    NSInteger newFinalIndex = copyOfTaskSteps.count - 2;
+    if (oldFinalIndex >= 0 && newFinalIndex >= 0) {
+        ORKActiveStep *oldFinalActiveStep = (ORKActiveStep *)[orkTask.steps objectAtIndex:oldFinalIndex];
+        ORKActiveStep *newFinalActiveStep = (ORKActiveStep *)[copyOfTaskSteps objectAtIndex:newFinalIndex];
+        if ([oldFinalActiveStep respondsToSelector:@selector(finishedSpokenInstruction)] &&
+            [newFinalActiveStep respondsToSelector:@selector(setFinishedSpokenInstruction:)]) {
+            newFinalActiveStep.finishedSpokenInstruction = oldFinalActiveStep.finishedSpokenInstruction;
+        }
+    }
+    
     orkTask = [[ORKOrderedTask alloc] initWithIdentifier:kWalkingActivityTitle steps:copyOfTaskSteps];
     
     return orkTask;

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -93,8 +93,14 @@ static  NSTimeInterval  kWalkDuration                         = 30.0; // we'll s
 //
 // constants for setting up the tremor activity
 //
-static NSString *const kTremorAssessmentTitleIdentifier     = @"Tremor Activity";
-static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
+static NSString *const kTremorElbowBentInstructionStepIdentifier    = @"instruction5";
+static NSString *const kTremorElbowBentCountdownStepIdentifier      = @"countdown3";
+static NSString *const kTremorElbowBentStepIdentifier               = @"tremor.handAtShoulderLengthWithElbowBent";
+static NSString *const kTremorQueenWaveInstructionStepIdentifier    = @"instruction7";
+static NSString *const kTremorQueenWaveCountdownStepIdentifier      = @"countdown5";
+static NSString *const kTremorQueenWaveStepIdentifier               = @"tremor.handQueenWave";
+static NSString *const kTremorAssessmentTitleIdentifier             = @"Tremor Activity";
+static NSTimeInterval kTremorAssessmentStepDuration                 = 10.0;
 
 
 @interface APHActivityManager ()
@@ -280,10 +286,27 @@ static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
 
 - (ORKOrderedTask *)createCustomTremorTask
 {
-    return [ORKOrderedTask tremorTestTaskWithIdentifier:kTremorAssessmentTitleIdentifier
-                                 intendedUseDescription:nil
-                                     activeStepDuration:kTremorAssessmentStepDuration
-                                                options:ORKPredefinedTaskOptionNone];
+    ORKOrderedTask *orkTask = [ORKOrderedTask tremorTestTaskWithIdentifier:kTremorAssessmentTitleIdentifier
+                                                    intendedUseDescription:nil
+                                                        activeStepDuration:kTremorAssessmentStepDuration
+                                                                   options:ORKPredefinedTaskOptionNone];
+    
+    // Remove the elbow-bent and queen wave steps
+    NSMutableArray  *copyOfTaskSteps = [orkTask.steps mutableCopy];
+    for (ORKStep *step  in  orkTask.steps) {
+        if ([step.identifier isEqualToString:kTremorElbowBentInstructionStepIdentifier] ||
+            [step.identifier isEqualToString:kTremorElbowBentCountdownStepIdentifier] ||
+            [step.identifier isEqualToString:kTremorElbowBentStepIdentifier] ||
+            [step.identifier isEqualToString:kTremorQueenWaveInstructionStepIdentifier] ||
+            [step.identifier isEqualToString:kTremorQueenWaveCountdownStepIdentifier] ||
+            [step.identifier isEqualToString:kTremorQueenWaveStepIdentifier]) {
+            [copyOfTaskSteps removeObject:step];
+        }
+    }
+    
+    orkTask = [[ORKOrderedTask alloc] initWithIdentifier:kWalkingActivityTitle steps:copyOfTaskSteps];
+    
+    return orkTask;
 }
 
 @end

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -286,39 +286,14 @@ static NSTimeInterval kTremorAssessmentStepDuration                 = 10.0;
 
 - (ORKOrderedTask *)createCustomTremorTask
 {
-    ORKOrderedTask *orkTask = [ORKOrderedTask tremorTestTaskWithIdentifier:kTremorAssessmentTitleIdentifier
-                                                    intendedUseDescription:nil
-                                                        activeStepDuration:kTremorAssessmentStepDuration
-                                                                   options:ORKPredefinedTaskOptionNone];
+    ORKTremorActiveTaskOption excludeTasks =
+        ORKTremorActiveTaskOptionExcludeHandAtShoulderHeightElbowBent |ORKTremorActiveTaskOptionExcludeQueenWave;
     
-    // Remove the elbow-bent and queen wave steps
-    NSMutableArray  *copyOfTaskSteps = [orkTask.steps mutableCopy];
-    for (ORKStep *step  in  orkTask.steps) {
-        if ([step.identifier isEqualToString:kTremorElbowBentInstructionStepIdentifier] ||
-            [step.identifier isEqualToString:kTremorElbowBentCountdownStepIdentifier] ||
-            [step.identifier isEqualToString:kTremorElbowBentStepIdentifier] ||
-            [step.identifier isEqualToString:kTremorQueenWaveInstructionStepIdentifier] ||
-            [step.identifier isEqualToString:kTremorQueenWaveCountdownStepIdentifier] ||
-            [step.identifier isEqualToString:kTremorQueenWaveStepIdentifier]) {
-            [copyOfTaskSteps removeObject:step];
-        }
-    }
-    
-    // move the "you're done" spoken instruction to the new last step
-    NSInteger oldFinalIndex = orkTask.steps.count - 2;
-    NSInteger newFinalIndex = copyOfTaskSteps.count - 2;
-    if (oldFinalIndex >= 0 && newFinalIndex >= 0) {
-        ORKActiveStep *oldFinalActiveStep = (ORKActiveStep *)[orkTask.steps objectAtIndex:oldFinalIndex];
-        ORKActiveStep *newFinalActiveStep = (ORKActiveStep *)[copyOfTaskSteps objectAtIndex:newFinalIndex];
-        if ([oldFinalActiveStep respondsToSelector:@selector(finishedSpokenInstruction)] &&
-            [newFinalActiveStep respondsToSelector:@selector(setFinishedSpokenInstruction:)]) {
-            newFinalActiveStep.finishedSpokenInstruction = oldFinalActiveStep.finishedSpokenInstruction;
-        }
-    }
-    
-    orkTask = [[ORKOrderedTask alloc] initWithIdentifier:kWalkingActivityTitle steps:copyOfTaskSteps];
-    
-    return orkTask;
+    return [ORKOrderedTask tremorTestTaskWithIdentifier:kTremorAssessmentTitleIdentifier
+                                 intendedUseDescription:nil
+                                     activeStepDuration:kTremorAssessmentStepDuration
+                                      activeTaskOptions:excludeTasks
+                                                options:ORKPredefinedTaskOptionNone];
 }
 
 @end


### PR DESCRIPTION
per Andrew, should only include lap, extended at shoulder height, and touching nose.

Also, since we don't yet know enough to create a score for Tremor, remove it from the dashboard for now (again per Andrew). A future release of mPower will add it back once we can analyze enough data to come up with a way to score it.
