### PR TITLE
Two-handed tremor, and app color

### DIFF
--- a/mPowerSDK/Startup/APHAppDelegate.m
+++ b/mPowerSDK/Startup/APHAppDelegate.m
@@ -104,7 +104,10 @@ static NSString *const kAppStoreLink                    = @"https://appsto.re/us
 
 - (NSDictionary * _Nonnull)appearanceInfo {
     return @{
-             kPrimaryAppColorKey : [UIColor purpleColor],
+             kPrimaryAppColorKey : [UIColor colorWithRed:88. / 255.
+                                                   green:55. / 255.
+                                                    blue:182. / 255.
+                                                   alpha:1.0],
              APHTappingActivitySurveyIdentifier : [UIColor appTertiaryPurpleColor],
              APHMemoryActivitySurveyIdentifier : [UIColor appTertiaryRedColor],
              APHVoiceActivitySurveyIdentifier : [UIColor appTertiaryBlueColor],

--- a/mPowerSDK/TasksAndSteps/APHActivityManager.m
+++ b/mPowerSDK/TasksAndSteps/APHActivityManager.m
@@ -154,7 +154,7 @@ static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
                                                                    intendedUseDescription:nil
                                                                                  duration:kTappingStepCountdownInterval
                                                                                   options:0
-                                                                              handOptions:APCTapHandOptionBoth];
+                                                                              handOptions:ORKPredefinedTaskHandOptionBoth];
     
     // Modify the first step to explain why this activity is valuable to the Parkinson's study
     ORKInstructionStep *firstStep = (ORKInstructionStep *)orkTask.steps.firstObject;
@@ -294,6 +294,7 @@ static NSTimeInterval kTremorAssessmentStepDuration         = 10.0;
                                  intendedUseDescription:nil
                                      activeStepDuration:kTremorAssessmentStepDuration
                                       activeTaskOptions:excludeTasks
+                                            handOptions:ORKPredefinedTaskHandOptionBoth
                                                 options:ORKPredefinedTaskOptionNone];
 }
 


### PR DESCRIPTION
fix primary app color to match the tulip logo on the study overview screen (since that image is not made in a way that allows it to take on the app tint color)
